### PR TITLE
Fixes bug Sidebar overlaps dialogs #187

### DIFF
--- a/src/components/respondent/AddRespondentForm.vue
+++ b/src/components/respondent/AddRespondentForm.vue
@@ -226,6 +226,7 @@
   }
 </script>
 
-<style scoped>
-
+<style lang="sass">
+  .dialog__content 
+    z-index: 1700 !important;
 </style>


### PR DESCRIPTION
the solution is just to increase the z-index of the dialog (z-index: 1700), it doesn't have to be responsive (move over) if the sidebar is open (z-index: 1600), it could just display on top of the sidebar.